### PR TITLE
Update release notes to current version

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -21,6 +21,20 @@ So version 2.1.1 would be named version 3.0.0 after a major release.
 
 :leveloffset: +1
 
+include::./v2.9.adoc[]
+
+include::./v2.8.adoc[]
+
+include::./v2.7.adoc[]
+
+include::./v2.6.adoc[]
+
+include::./v2.5.adoc[]
+
+include::./v2.4.adoc[]
+
+include::./v2.3.adoc[]
+
 include::./v2.2.adoc[]
 
 include::./v2.1.adoc[]

--- a/docs/v2.2.adoc
+++ b/docs/v2.2.adoc
@@ -14,7 +14,7 @@ This is a read-only connector.
 
 == 2.2.22 - Three-part relational scopes
 
-Support for three-part relational scopes have been added. The previous valid scope values will still work and map to such a three-part relational scope. For more information see https://docs.xill.io/#_scopes_for_entities[Scopes for Entities].
+Support for three-part relational scopes have been added. The previous valid scope values still work and map to equivalent three-part relational scope. For more information see https://docs.xill.io/#_scopes_for_entities[Scopes for Entities].
 
 == 2.2.21 - Add Bookmark data type to Box connector
 

--- a/docs/v2.2.adoc
+++ b/docs/v2.2.adoc
@@ -1,9 +1,20 @@
-= Version 2.2
+= Version 2.2 (07-03-2019)
 
-This version adds two new connectors:
+This version adds three new connectors:
 
 - https://docs.xill.io/#connector-s3[S3]
 - https://docs.xill.io/#connector-wordpress[WordPress]
+- https://docs.xill.io/#connector-gitlab[GitLab]
+
+== 2.2.31 - GitLab Connector read operations
+
+A new connector is released: https://docs.xill.io/#connector-gitlab[GitLab].
+
+This is a read-only connector.
+
+== 2.2.22 - Three-part relational scopes
+
+Support for three-part relational scopes have been added. The previous valid scope values will still work and map to such a three-part relational scope. For more information see https://docs.xill.io/#_scopes_for_entities[Scopes for Entities].
 
 == 2.2.21 - Add Bookmark data type to Box connector
 

--- a/docs/v2.3.adoc
+++ b/docs/v2.3.adoc
@@ -1,6 +1,24 @@
-= Version 2.3 (current)
+= Version 2.3 (03-05-2019)
 
-This version adds the Configuration Manager.
+Version 2.3.0 adds the Configuration Manager.
+
+This version also adds a new connector: https://docs.xill.io/#connector-zendesk[Zendesk]
+
+== 2.3.14 - Zendesk Connector
+
+This version adds the Zendesk connector. This connector supports read and write functionality.
+
+== 2.3.12 - WordPress media posts translation support
+
+Media posts now support the translation use-case through the language decorator and translation scope features.
+
+== 2.3.4 - GitLab Connector write operations
+
+The GitLab connector now supports write capabilities on folders and files.
+
+== 2.3.1 - Configuration Manager
+
+Internally generated error IDs are now exposed in the JSON body response. This error ID value is also printed in the logs, allowing for easier identification of what happened.
 
 == 2.3.0 - Configuration Manager
 

--- a/docs/v2.4.adoc
+++ b/docs/v2.4.adoc
@@ -1,0 +1,15 @@
+= Version 2.4 (13-06-2019)
+
+Version 2.4.0 adds a new feature to Xillio API called 'RPC endpoints'.
+
+== 2.4.5 - Configuration manager user profile
+
+The configuration manager now has a 'Profile' page where you can edit your own user's information, such as email address or password.
+
+== 2.4.4 - Zendesk translation scope support
+
+The Zendesk connector now supports the translation scope. This provides support to creating translations of articles and exposing an article's language.
+
+== 2.4.0 - RPC endpoints
+
+With RPC endpoints, Xillio can create custom endpoints for customers to use that extend a connector's functionality. These endpoints are connector-specific and are therefore not unified.

--- a/docs/v2.5.adoc
+++ b/docs/v2.5.adoc
@@ -1,0 +1,36 @@
+= Version 2.5 (18-10-2019)
+
+Version 2.5.0 adds a new endpoint to the Xillio API: Search.
+
+This version also adds two new connectors:
+- https://docs.xill.io/#connector-salesforce[Salesforce Knowledge]
+- https://docs.xill.io/#connector-aem[Adobe Experience Manager (AEM)]
+
+== 2.5.19 - Salesforce Knowledge write operations
+
+This version adds write functionality to the Salesforce Knowledge connector.
+
+== 2.5.15 - Custom Post types support in WordPress
+
+With this version, custom Post types support is added to the WordPress connector. This support is added for both read and write functionality.
+
+== 2.5.8 - Adobe Experience Manager read operations
+
+This version adds the Adobe Experience Manager (AEM) connector. This connector supports only read functionality.
+
+== 2.5.8 - Salesforce Knowledge read operations
+
+This version adds the Salesforce Knowledge connector. This connector supports only read functionality.
+
+== 2.5.7 - Improved documentation in configuration manager
+
+When setting up a configuration in the configuration manager, you can now hover 'question-mark' icons to show more information about the field. Clicking this icon will forward you to the connector's documentation chapter.
+
+== 2.5.1 - GitLab personal access token support
+
+The GitLab connector now supports the usage of personal access tokens as authentication.
+
+== 2.5.0 - Unified Search
+
+Version 2.5.0 adds a new endpoint to the Xillio API: https://docs.xill.io/#Search[unified search]. The search endpoint allows you to search through the target repository by textual content. This endpoint is dependent on a system's search capabilities and therefore returns results based on the system's search implementation.
+

--- a/docs/v2.6.adoc
+++ b/docs/v2.6.adoc
@@ -1,0 +1,13 @@
+= Version 2.6 (04-06-2020)
+
+This version also adds a new connector: https://docs.xill.io/#connector-json-rpc[JSON RPC] (custom connector).
+
+== 2.6.9 - FileNet connector metadata and query functionality
+
+With this release, metadata and query functionality has been added to the FileNet connector.
+
+== 2.6.0 - JSON RPC connector
+
+This version adds the JSON RPC connector. This connector allows third-parties to create and host connectors and then add them to the Xillio API infrastructure. This allows any system the be added to the Xillio API.
+
+The server must adhere to the JSON RPC protocol which is furthermore bounded by Xillio API's requirements on contents of requests and responses. For more information and documentation on creating such a custom connector, please contact us.

--- a/docs/v2.6.adoc
+++ b/docs/v2.6.adoc
@@ -1,6 +1,6 @@
 = Version 2.6 (04-06-2020)
 
-This version also adds a new connector: https://docs.xill.io/#connector-json-rpc[JSON RPC] (custom connector).
+This version adds a new connector: https://docs.xill.io/#connector-json-rpc[JSON RPC] (custom connector).
 
 == 2.6.9 - FileNet connector metadata and query functionality
 
@@ -10,4 +10,4 @@ With this release, metadata and query functionality has been added to the FileNe
 
 This version adds the JSON RPC connector. This connector allows third-parties to create and host connectors and then add them to the Xillio API infrastructure. This allows any system the be added to the Xillio API.
 
-The server must adhere to the JSON RPC protocol which is furthermore bounded by Xillio API's requirements on contents of requests and responses. For more information and documentation on creating such a custom connector, please contact us.
+The server must adhere to the JSON RPC protocol which is bounded by Xillio API's requirements on contents of requests and responses. For more information and documentation on creating such a custom connector, please contact us.

--- a/docs/v2.7.adoc
+++ b/docs/v2.7.adoc
@@ -1,0 +1,3 @@
+= Version 2.7 (14-07-2020)
+
+Version 2.7.0 allows OpenText's baseUrl path to be configurable in order to support more advanced API setups.

--- a/docs/v2.8.adoc
+++ b/docs/v2.8.adoc
@@ -1,3 +1,3 @@
 = Version 2.8 (21-07-2020)
 
-Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. The connector does have to support this feature in order to use it properly.
+Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. Connectors have to support this feature in order to use it properly.

--- a/docs/v2.8.adoc
+++ b/docs/v2.8.adoc
@@ -1,0 +1,3 @@
+= Version 2.8 (21-07-2020)
+
+Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. The connector does have to support this feature in order to use it properly.

--- a/docs/v2.8.adoc
+++ b/docs/v2.8.adoc
@@ -1,3 +1,3 @@
 = Version 2.8 (21-07-2020)
 
-Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. Connectors have to support this feature in order to use it properly.
+Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. Connectors have to support this feature.

--- a/docs/v2.8.adoc
+++ b/docs/v2.8.adoc
@@ -1,3 +1,3 @@
 = Version 2.8 (21-07-2020)
 
-Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. Connectors have to support this feature.
+Version 2.8.0 adds https://docs.xill.io/#pagination[pagination support] to the Xillio API. With pagination, you can request subsets of results. This allows you to minimize the result set to your needs and therefore have increased performance. Individual connectors may or may not support this feature.

--- a/docs/v2.9.adoc
+++ b/docs/v2.9.adoc
@@ -2,11 +2,11 @@
 
 Version 2.9.0 adds a new decorator to the Entity structure: https://docs.xill.io/#decorator_workflow[Workflow decorator].
 
-This connector furthermore adds the https://docs.xill.io/#connector-drupal[Drupal connector].
+This release furthermore adds the https://docs.xill.io/#connector-drupal[Drupal connector].
 
 == 2.9.10 - Drupal connector write operations
 
-This version adds write functionality to the Salesforce Knowledge connector. It furthermore adds pagination support to the Drupal connector.
+This version adds write functionality and pagination support to the Drupal connector.
 
 == 2.9.8 - OpenText pagination support
 
@@ -22,5 +22,4 @@ The configuration manager and landing page have been redesigned to suit Xillio's
 
 == 2.9.0 - Added workflow decorator
 
-The workflow decorator signifies the state of the entity in the workflow of the target system. In web content management systems (WCMs), this is often used to denote the state of publication; draft or published. This decorator is implemented in the WordPress and Zendesk connector with this release.
-
+The workflow decorator signifies the state of the entity in the workflow of the target system. In web content management systems (WCMs), this is often used to denote the state of publication; draft or published. This decorator is implemented in the WordPress and Zendesk connectors with this release.

--- a/docs/v2.9.adoc
+++ b/docs/v2.9.adoc
@@ -1,0 +1,26 @@
+= Version 2.9 (current)
+
+Version 2.9.0 adds a new decorator to the Entity structure: https://docs.xill.io/#decorator_workflow[Workflow decorator].
+
+This connector furthermore adds the https://docs.xill.io/#connector-drupal[Drupal connector].
+
+== 2.9.10 - Drupal connector write operations
+
+This version adds write functionality to the Salesforce Knowledge connector. It furthermore adds pagination support to the Drupal connector.
+
+== 2.9.8 - OpenText pagination support
+
+The OpenText connector now supports the pagination feature.
+
+== 2.9.7 - Drupal connector read operations
+
+This version adds the Drupal connector. This connector supports only read functionality.
+
+== 2.9.3 - Redesign of configuration manager
+
+The configuration manager and landing page have been redesigned to suit Xillio's new house style.
+
+== 2.9.0 - Added workflow decorator
+
+The workflow decorator signifies the state of the entity in the workflow of the target system. In web content management systems (WCMs), this is often used to denote the state of publication; draft or published. This decorator is implemented in the WordPress and Zendesk connector with this release.
+


### PR DESCRIPTION
This PR updates the release notes up until the current version (2.9.12). As was done in previous release notes, this only contains noteworthy changes to the Xillio API. Bug fixes or internal fixes are not included in these release notes. 