### PR TITLE
XD-155 - Update release notes on 2.10 

### DIFF
--- a/docs/v2.10.adoc
+++ b/docs/v2.10.adoc
@@ -1,0 +1,14 @@
+= Version 2.10 (current)
+
+Version 2.10.0 comes with major internal changes as part of maintenance for this product.
+
+== 2.10.2 - Java 11 upgrade
+
+Xillio API is now built with the latest long term support Java version 11.
+
+== 2.10.0 - Major internal dependencies upgrade
+
+With this release, many internal dependencies have been upgraded or replaced. Please contact us if you are experiencing
+any problems with this release https://support.xill.io/support/home[at our support site].
+
+

--- a/docs/v2.9.adoc
+++ b/docs/v2.9.adoc
@@ -1,8 +1,24 @@
-= Version 2.9 (current)
+= Version 2.9 (05-02-2021)
 
 Version 2.9.0 adds a new decorator to the Entity structure: https://docs.xill.io/#decorator_workflow[Workflow decorator].
 
 This release furthermore adds the https://docs.xill.io/#connector-drupal[Drupal connector].
+
+== 2.9.15 - Drupal custom workflow support
+
+The Drupal connector now is better capable to work with Drupal workflows. With this release, you can now also manage
+your nodes using your custom workflows defined in Drupal.
+
+== 2.9.14 - Drupal translation scope support
+
+The Drupal connector now supports the `translation` relation type in the `scope` query parameter. This allows you
+to list, retrieve, create and update translations within Drupal. Please read the
+https://docs.xill.io/#connector-drupal[connector's documentation] for additional configuration parameters, features
+and limitations for this translation support.
+
+== 2.9.11 - Opentext connector file decorator
+
+The Opentext connector now exposes the `file` decorator when possible.
 
 == 2.9.10 - Drupal connector write operations
 


### PR DESCRIPTION
As part of release 2.10.0 to 2.10.2 we have upgraded major dependencies in our `xillio-engine` image. 
This PR updates the release notes to reflect those changes. Furthermore, it adds release notes for prior releases in 2.9.x. 

Fixes [XD-155](https://xillio.atlassian.net/browse/XD-155)